### PR TITLE
Update composer.json files. to allow versions 2.3 ~ 2.6 (>=2.3,<2.7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": ">=2.3,<2.7",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
## summary

This bundle does't work in Symfony2.7.
So I update `composer.json to allow versions 2.3 ~ 2.6 (>=2.3,<2.7)
