### PR TITLE
Support for PHP 8.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,9 @@ jobs:
           - php-version: 7.4
             composer-flags: "--prefer-stable"
             symfony-require: "3.4.*"
+          - php-version: 8.0
+            composer-flags: "--prefer-stable"
+            symfony-require: "3.4.*"
           # When adding support for Symfony4, restore these comments
           # - php-version: 7.4
           #   composer-flags: "--prefer-stable"

--- a/Tests/DBAL/Types/AbstractSetTypeTest.php
+++ b/Tests/DBAL/Types/AbstractSetTypeTest.php
@@ -24,12 +24,12 @@ class AbstractSetTypeTest extends TestCase
      */
     private $type;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Type::addType('UserGroupType', UserGroupType::class);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->type = Type::getType('UserGroupType');
     }

--- a/Tests/Form/Guess/SetTypeGuesserTest.php
+++ b/Tests/Form/Guess/SetTypeGuesserTest.php
@@ -24,7 +24,7 @@ class SetTypeGuesserTest extends TestCase
      */
     private $guesser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $managerRegistry = Phake::mock(ManagerRegistry::class);
         $registeredTypes = ['UserGroupType' => ['class' => UserGroupType::class]];

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phake/phake": "^3.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phake/phake": "^3.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phake/phake": "^3.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# 目的
PHP8.0 ＆ Symfony 3.4.x でテストを通す。

# 対応内容
- テスト対象に PHP 8.0 ＆ Symfony 3.4.x を追加
- PHPUnit のバージョンを `^7.0` から `^9.0` に変更
- テストケースの修正（返り値の型宣言を追加）

<details>
<summary>対応内容の補足</summary>

## PHPUnit のバージョンについて

- #4 の対応で PHP バージョンが 7.4 以上となった
- [PHPUnit のバージョン対応表](https://phpunit.de/supported-versions.html) より `>=7.3` なら PHPUnit 9 が使える

ことより `^7.0` から `^9.0` に一気に上げています。

あとは、PHPUnit 8 の End of Bugfix Support が今年の 2月で終わっていることもあり、使えるなら新しい方がいいかなと。
PHPUnit 8 でも 9 でも CI で出たエラーは同じでした。（どちらを選んでもこのパッケージの修正内容は同じ）

## CI で出たエラーについて

PHPUnit 8 や 9 に上げると下記のエラーが出たので、 `: void` の型宣言を追加しました。

![スクリーンショット 2023-07-03 14 55 52](https://github.com/raksul/DoctrineSetTypeBundle/assets/37787659/cdbe4d0c-90bb-47ec-9d8b-d4368e46a987)

参考：https://qiita.com/ismt7/items/fcc898f38ee161b38ef4

>その動きに合わせてPHPUnitでも8.xから型宣言をする形式に実装を修正されているみたいです。そのことを踏まえると呼び出し側でも後で記載しているような実装をする必要があります。実際に試していないで推測ですが、7.xを利用している人は上記のようなエラーは表示されないのではないかと思います。

> 先に結論から言うと、setUp()に戻り値型の: voidの宣言を記述すると上手くいきました。
</details>