### PR TITLE
drop support symfony2.8 and symfony4.x(which is not  completely implemented)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/symfony": "^2.8|^3.0|^4.0",
+        "symfony/symfony": "^3.0",
         "doctrine/orm": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
* Symfony2.8のサポートを完全に落とす
* Symofny4系がまだサポートできてないので一旦消します。